### PR TITLE
feat: add animated async evaluation form

### DIFF
--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const prisma = new PrismaClient();
 app.set('view engine', 'ejs');
 app.use(express.static('public'));
 app.use(bodyParser.urlencoded({ extended: true }));
+app.use(express.json());
 
 const preguntas = [
   "¿Con qué frecuencia estudias fuera del horario de clases?",
@@ -98,6 +99,31 @@ app.post('/', async (req, res) => {
     puntaje,
     porcentaje
   });
+});
+
+app.post('/api/evaluacion', async (req, res) => {
+  const datos = req.body;
+  const nombre = datos.nombre;
+  let puntaje = 0;
+  let maxPuntaje = preguntas.length * 3;
+
+  for (let i = 1; i <= preguntas.length; i++) {
+    puntaje += parseInt(datos[`p${i}`]) || 0;
+  }
+
+  const { resultado, razon, recomendaciones, porcentaje } = generarRecomendaciones(puntaje, maxPuntaje);
+
+  await prisma.Evaluacion.create({
+    data: {
+      nombre,
+      puntaje,
+      maxPuntaje,
+      porcentaje,
+      resultado
+    }
+  });
+
+  res.json({ resultado, razon, recomendaciones, puntaje, porcentaje, maxPuntaje });
 });
 
 app.listen(3000, () => {

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,0 +1,8 @@
+/* Custom styles for formulario */
+#resultado .alert {
+  animation-duration: 0.8s;
+}
+
+#progressBar {
+  transition: width 0.5s ease-in-out;
+}

--- a/public/js/formulario.js
+++ b/public/js/formulario.js
@@ -1,0 +1,57 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.querySelector('form');
+  const resultadoDiv = document.getElementById('resultado');
+  let chart;
+
+  form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const formData = new FormData(form);
+    const data = {};
+    formData.forEach((value, key) => data[key] = value);
+
+    try {
+      const response = await fetch('/api/evaluacion', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+      const res = await response.json();
+
+      resultadoDiv.innerHTML = `
+        <div class="alert alert-info animate__animated animate__fadeInUp">
+          <h4>${res.resultado}</h4>
+          <p><strong>Puntaje:</strong> ${res.puntaje} / ${res.maxPuntaje}</p>
+          <p><strong>Porcentaje:</strong> ${res.porcentaje.toFixed(2)}%</p>
+          <p><strong>Razón del resultado:</strong> ${res.razon}</p>
+          <h5 class="mt-3">🔍 Recomendaciones personalizadas:</h5>
+          <ul>${res.recomendaciones.map(r => `<li>${r}</li>`).join('')}</ul>
+        </div>
+        <div class="progress mt-3 animate__animated animate__fadeInUp">
+          <div id="progressBar" class="progress-bar" role="progressbar" style="width:0%"></div>
+        </div>
+        <canvas id="resultChart" class="mt-3"></canvas>
+      `;
+
+      const progressBar = document.getElementById('progressBar');
+      progressBar.style.width = `${res.porcentaje}%`;
+      progressBar.textContent = `${res.porcentaje.toFixed(2)}%`;
+
+      const ctx = document.getElementById('resultChart');
+      const remaining = 100 - res.porcentaje;
+      if (chart) chart.destroy();
+      chart = new Chart(ctx, {
+        type: 'doughnut',
+        data: {
+          labels: ['Obtenido', 'Restante'],
+          datasets: [{
+            data: [res.porcentaje, remaining],
+            backgroundColor: ['#0d6efd', '#e9ecef']
+          }]
+        }
+      });
+    } catch (err) {
+      resultadoDiv.innerHTML = `<div class="alert alert-danger">Error al procesar la evaluación</div>`;
+      console.error(err);
+    }
+  });
+});

--- a/views/formulario.ejs
+++ b/views/formulario.ejs
@@ -1,14 +1,16 @@
 <!DOCTYPE html>
 <html lang="es">
-<head>
-  <meta charset="UTF-8">
-  <title>Evaluación Académica</title>
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
-</head>
-<body class="bg-light">
-  <div class="container mt-5">
-    <h2>Formulario de Evaluación</h2>
-    <form method="POST">
+  <head>
+    <meta charset="UTF-8">
+    <title>Evaluación Académica</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"/>
+    <link rel="stylesheet" href="/css/style.css">
+  </head>
+  <body class="bg-light">
+    <div class="container mt-5 animate__animated animate__fadeIn">
+      <h2>Formulario de Evaluación</h2>
+      <form method="POST">
       <div class="mb-3">
         <label class="form-label">Nombre del estudiante:</label>
         <input type="text" name="nombre" class="form-control" required>
@@ -27,23 +29,11 @@
       <% }) %>
 
       <button type="submit" class="btn btn-primary">Enviar evaluación</button>
-    </form>
+      </form>
 
-    <% if (resultado) { %>
-      <div class="alert alert-info mt-4">
-        <h4><%= resultado %></h4>
-        <p><strong>Puntaje:</strong> <%= puntaje %> / <%= (preguntas.length * 3) %></p>
-        <p><strong>Porcentaje:</strong> <%= porcentaje.toFixed(2) %>%</p>
-        <p><strong>Razón del resultado:</strong> <%= razon %></p>
-
-        <h5 class="mt-3">🔍 Recomendaciones personalizadas:</h5>
-        <ul>
-          <% recomendaciones.forEach(rec => { %>
-            <li><%= rec %></li>
-          <% }) %>
-        </ul>
-      </div>
-    <% } %>
-  </div>
-</body>
-</html>
+      <div id="resultado" class="mt-4"></div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="/js/formulario.js"></script>
+  </body>
+  </html>


### PR DESCRIPTION
## Summary
- add public css/js and hook them into formulario
- implement asynchronous evaluation endpoint with progress and charts
- apply animate.css effects for form and results

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68961f29d8b483279f3d37029fcb8724