### PR TITLE
Remove chart visualization from evaluation results

### DIFF
--- a/public/js/formulario.js
+++ b/public/js/formulario.js
@@ -1,7 +1,6 @@
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.querySelector('form');
   const resultadoDiv = document.getElementById('resultado');
-  let chart;
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
@@ -21,34 +20,16 @@ document.addEventListener('DOMContentLoaded', () => {
         <div class="alert alert-info animate__animated animate__fadeInUp">
           <h4>${res.resultado}</h4>
           <p><strong>Puntaje:</strong> ${res.puntaje} / ${res.maxPuntaje}</p>
-          <p><strong>Porcentaje:</strong> ${res.porcentaje.toFixed(2)}%</p>
-          <p><strong>Razón del resultado:</strong> ${res.razon}</p>
-          <h5 class="mt-3">🔍 Recomendaciones personalizadas:</h5>
-          <ul>${res.recomendaciones.map(r => `<li>${r}</li>`).join('')}</ul>
         </div>
         <div class="progress mt-3 animate__animated animate__fadeInUp">
           <div id="progressBar" class="progress-bar" role="progressbar" style="width:0%"></div>
         </div>
-        <canvas id="resultChart" class="mt-3"></canvas>
       `;
 
       const progressBar = document.getElementById('progressBar');
       progressBar.style.width = `${res.porcentaje}%`;
       progressBar.textContent = `${res.porcentaje.toFixed(2)}%`;
 
-      const ctx = document.getElementById('resultChart');
-      const remaining = 100 - res.porcentaje;
-      if (chart) chart.destroy();
-      chart = new Chart(ctx, {
-        type: 'doughnut',
-        data: {
-          labels: ['Obtenido', 'Restante'],
-          datasets: [{
-            data: [res.porcentaje, remaining],
-            backgroundColor: ['#0d6efd', '#e9ecef']
-          }]
-        }
-      });
     } catch (err) {
       resultadoDiv.innerHTML = `<div class="alert alert-danger">Error al procesar la evaluación</div>`;
       console.error(err);

--- a/views/formulario.ejs
+++ b/views/formulario.ejs
@@ -38,7 +38,6 @@
 
       <div id="resultado" class="mt-4"></div>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="/js/formulario.js"></script>
   </body>
   </html>


### PR DESCRIPTION
## Summary
- Remove Chart.js dependency and canvas from evaluation form
- Simplify result rendering to show only message, score, and progress bar

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68962247b3308327a855a65bd73e7a4f