### PR TITLE
Agrega navegación paso a paso al formulario

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,4 +1,12 @@
 /* Custom styles for formulario */
+/* Ocultar preguntas por defecto */
+.question-step {
+  display: none;
+}
+
+.question-step.active {
+  display: block;
+}
 #resultado .alert {
   animation-duration: 0.8s;
 }

--- a/public/js/formulario.js
+++ b/public/js/formulario.js
@@ -1,7 +1,28 @@
 document.addEventListener('DOMContentLoaded', () => {
   const form = document.querySelector('form');
+  const pasos = document.querySelectorAll('.question-step');
   const resultadoDiv = document.getElementById('resultado');
   let chart;
+
+  let pasoActual = 0;
+  const mostrarPaso = (indice) => {
+    pasos.forEach((p, i) => p.classList.toggle('active', i === indice));
+  };
+  mostrarPaso(pasoActual);
+
+  pasos.forEach((paso, idx) => {
+    const select = paso.querySelector('select');
+    const btn = paso.querySelector('.next-btn');
+    btn.addEventListener('click', () => {
+      if (!select.value) return;
+      if (idx === pasos.length - 1) {
+        form.submit();
+      } else {
+        pasoActual++;
+        mostrarPaso(pasoActual);
+      }
+    });
+  });
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();

--- a/views/formulario.ejs
+++ b/views/formulario.ejs
@@ -19,9 +19,10 @@
       <% preguntas.forEach((p, i) => {
         const rec = recomendacionesPreguntas.find(r => r.indice === i);
       %>
-        <div class="mb-3">
+        <div class="mb-3 question-step <%= i === 0 ? 'active' : '' %>">
           <label class="form-label <%= rec ? 'text-danger' : '' %>"><strong><%= i+1 %>. <%= p %></strong></label>
           <select name="p<%= i+1 %>" class="form-select <%= rec ? 'border border-danger' : '' %>" required>
+            <option value="" <%= respuestas[i] === undefined ? 'selected' : '' %> disabled>Selecciona una opción</option>
             <option value="3" <%= respuestas[i] === 3 ? 'selected' : '' %>>Excelente / Siempre / Frecuente</option>
             <option value="2" <%= respuestas[i] === 2 ? 'selected' : '' %>>Bueno / A veces / Parcial</option>
             <option value="1" <%= respuestas[i] === 1 ? 'selected' : '' %>>Poco / Rara vez</option>
@@ -30,10 +31,9 @@
           <% if (rec) { %>
             <div class="form-text text-danger"><%= rec.sugerencia %></div>
           <% } %>
+          <button type="button" class="btn btn-primary next-btn"><%= i === preguntas.length - 1 ? 'Enviar' : 'Siguiente' %></button>
         </div>
       <% }) %>
-
-      <button type="submit" class="btn btn-primary">Enviar evaluación</button>
       </form>
 
       <div id="resultado" class="mt-4"></div>


### PR DESCRIPTION
## Summary
- Añade opción inicial deshabilitada en cada pregunta y botones para avanzar
- Implementa lógica en JavaScript para mostrar una pregunta a la vez y enviar al final
- Ajusta estilos para ocultar pasos inactivos y mostrar el activo

## Testing
- `npm test` *(falla: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6896224746588327951fc09e96066825