### PR TITLE
chore: ignore binary model artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 .env
 
 /generated/prisma
+*.bin
+


### PR DESCRIPTION
## Summary
- ignore `*.bin` files to prevent accidental commits of binary model artifacts
- confirm the app uses JSON-based model data instead of binary formats

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68962491cdf483279b7f2fce55e63e0f