### PR TITLE
Validate nombre field before processing

### DIFF
--- a/app.js
+++ b/app.js
@@ -66,6 +66,19 @@ function predecirRiesgo(puntaje, maxPuntaje) {
   return { resultado, razon, recomendaciones, porcentaje };
 }
 
+function generarRecomendaciones(puntaje, maxPuntaje) {
+  const porcentaje = (puntaje / maxPuntaje) * 100;
+  let resultado = '';
+  if (porcentaje >= 66) {
+    resultado = '✅ Alta probabilidad de éxito académico';
+  } else if (porcentaje >= 33) {
+    resultado = '⚠️ Riesgo moderado';
+  } else {
+    resultado = '❌ Alta probabilidad de queme o abandono';
+  }
+  return { resultado, porcentaje };
+}
+
 const preguntas = [
   "¿Con qué frecuencia estudias fuera del horario de clases?",
   "¿Tienes un horario de estudio semanal?",
@@ -114,6 +127,9 @@ app.get('/', (req, res) => {
 app.post('/', async (req, res) => {
   const datos = req.body;
   const nombre = datos.nombre;
+  if (!nombre || !nombre.trim()) {
+    return res.status(400).send('Nombre requerido');
+  }
   let puntaje = 0;
   const maxPuntaje = preguntas.length * 3;
   const recomendacionesPreguntas = [];
@@ -159,6 +175,9 @@ app.post('/', async (req, res) => {
 app.post('/api/evaluacion', async (req, res) => {
   const datos = req.body;
   const nombre = datos.nombre;
+  if (!nombre || !nombre.trim()) {
+    return res.status(400).json({ error: 'Nombre requerido' });
+  }
   let puntaje = 0;
   let maxPuntaje = preguntas.length * 3;
 
@@ -193,7 +212,10 @@ app.post('/api/retrain', async (req, res) => {
   res.json({ status: 'Modelo reentrenado' });
 });
 
-app.listen(3000, () => {
-  console.log("Servidor corriendo en http://localhost:3000");
-});
+if (require.main === module) {
+  app.listen(3000, () => {
+    console.log("Servidor corriendo en http://localhost:3000");
+  });
+}
 
+module.exports = { app, generarRecomendaciones };

--- a/public/js/formulario.js
+++ b/public/js/formulario.js
@@ -3,6 +3,17 @@ document.addEventListener('DOMContentLoaded', () => {
   const pasos = document.querySelectorAll('.question-step');
   const resultadoDiv = document.getElementById('resultado');
   const barraPreguntas = document.getElementById('preguntasProgress');
+  const nombreInput = document.querySelector('input[name="nombre"]');
+
+  const validarNombre = () => {
+    const nombre = nombreInput.value.trim();
+    if (!nombre) {
+      alert('Por favor ingresa tu nombre');
+      nombreInput.focus();
+      return false;
+    }
+    return true;
+  };
 
   let pasoActual = 0;
 
@@ -30,6 +41,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const feedback = paso.querySelector('.feedback');
 
     btn.addEventListener('click', () => {
+      if (!validarNombre()) return;
       if (!select.value) return;
 
       const valor = parseInt(select.value, 10);
@@ -67,6 +79,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
+    if (!validarNombre()) return;
     const formData = new FormData(form);
     const data = {};
     formData.forEach((value, key) => data[key] = value);

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -29,4 +29,13 @@ describe('Rutas principales', () => {
     expect(res.body).toHaveProperty('maxPuntaje', 45);
     expect(res.body).toHaveProperty('porcentaje', 100);
   });
+
+  test('POST /api/evaluacion responde 400 si falta nombre', async () => {
+    const body = {};
+    for (let i = 1; i <= 15; i++) {
+      body[`p${i}`] = 3;
+    }
+    const res = await request(app).post('/api/evaluacion').send(body);
+    expect(res.statusCode).toBe(400);
+  });
 });


### PR DESCRIPTION
## Summary
- Validate `nombre` in browser before navigating through questions or submitting
- Return 400 on server when `nombre` is missing or blank
- Test `/api/evaluacion` error when `nombre` is absent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689640d71e8483278783d56afd0e312a