### PR TITLE
Use requestSubmit to trigger form submit listener

### DIFF
--- a/public/js/formulario.js
+++ b/public/js/formulario.js
@@ -64,7 +64,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
       setTimeout(() => {
         if (idx === pasos.length - 1) {
-          form.submit();
+          form.requestSubmit();
         } else {
           paso.classList.add('animate__fadeOut');
           setTimeout(() => {


### PR DESCRIPTION
## Summary
- Use `form.requestSubmit()` to trigger the form's submit event when finishing the last step

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689644aa24f48327a8675899673da5c2