### PR TITLE
Render recommendations in result

### DIFF
--- a/public/js/formulario.js
+++ b/public/js/formulario.js
@@ -107,11 +107,18 @@ document.addEventListener('DOMContentLoaded', () => {
         respuestasHTML = `<h5>Respuestas:</h5><ul>${items}</ul>`;
       }
 
+      const recomendaciones = res.recomendaciones
+        ? `<h5>¿Cómo mejorar?</h5><ul>${res.recomendaciones.map(r => `<li>${r}</li>`).join('')}</ul>`
+        : '';
+      const razon = res.razon ? `<p>${res.razon}</p>` : '';
+
       resultadoDiv.innerHTML = `
         <div class="alert alert-info animate__animated animate__fadeInUp">
           <h4>${res.resultado}</h4>
+          ${razon}
           <p><strong>Estudiante:</strong> ${res.nombre}</p>
           <p><strong>Puntaje:</strong> ${res.puntaje} / ${res.maxPuntaje}</p>
+          ${recomendaciones}
           <img src="${imgSrc}" alt="${res.resultado}" class="resultado-img"/>
           ${respuestasHTML}
         </div>

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -28,6 +28,9 @@ describe('Rutas principales', () => {
     expect(res.body).toHaveProperty('puntaje', 45);
     expect(res.body).toHaveProperty('maxPuntaje', 45);
     expect(res.body).toHaveProperty('porcentaje', 100);
+    expect(res.body).toHaveProperty('razon');
+    expect(Array.isArray(res.body.recomendaciones)).toBe(true);
+    expect(res.body.recomendaciones.length).toBeGreaterThan(0);
   });
 
   test('POST /api/evaluacion incluye campo resultado para animación', async () => {


### PR DESCRIPTION
## Summary
- Display rationale and personalized recommendations in evaluation results
- Test that API responses include rationale and recommendation list

## Testing
- `npm test`
- `node` script verifying /api/evaluacion returns razon and recomendaciones


------
https://chatgpt.com/codex/tasks/task_e_68964685a2048327bd40dd0422b0d7c8