### PR TITLE
Validate and return student name

### DIFF
--- a/app.js
+++ b/app.js
@@ -173,15 +173,16 @@ app.post('/', async (req, res) => {
 });
 
 app.post('/api/evaluacion', async (req, res) => {
-  const datos = req.body;
-
-  const { nombre, ...respuestas } = datos;
+  const { nombre, ...respuestas } = req.body;
+  if (!nombre) {
+    return res.status(400).json({ error: 'Nombre requerido' });
+  }
 
   let puntaje = 0;
   let maxPuntaje = preguntas.length * 3;
 
   for (let i = 1; i <= preguntas.length; i++) {
-    puntaje += parseInt(datos[`p${i}`]) || 0;
+    puntaje += parseInt(respuestas[`p${i}`]) || 0;
   }
 
   const { resultado, razon, recomendaciones, porcentaje } = predecirRiesgo(puntaje, maxPuntaje);

--- a/public/js/formulario.js
+++ b/public/js/formulario.js
@@ -99,23 +99,25 @@ document.addEventListener('DOMContentLoaded', () => {
         imgSrc = '/img/riesgo_moderado.svg';
       }
 
-      let respuestasHTML = '';
-      if (res.respuestas) {
-        const items = Object.entries(res.respuestas)
-          .map(([k, v]) => `<li><strong>${k}:</strong> ${v}</li>`)
-          .join('');
-        respuestasHTML = `<h5>Respuestas:</h5><ul>${items}</ul>`;
-      }
+        let respuestasHTML = '';
+        if (res.respuestas) {
+          const items = Object.entries(res.respuestas)
+            .map(([k, v]) => `<li><strong>${k}:</strong> ${v}</li>`)
+            .join('');
+          respuestasHTML = `<h5>Respuestas:</h5><ul>${items}</ul>`;
+        }
 
-      resultadoDiv.innerHTML = `
-        <div class="alert alert-info animate__animated animate__fadeInUp">
-          <h4>${res.resultado}</h4>
-          <p><strong>Estudiante:</strong> ${res.nombre}</p>
-          <p><strong>Puntaje:</strong> ${res.puntaje} / ${res.maxPuntaje}</p>
-          <img src="${imgSrc}" alt="${res.resultado}" class="resultado-img"/>
-          ${respuestasHTML}
-        </div>
-        <div class="progress mt-3 animate__animated animate__fadeInUp">
+        const nombre = res.nombre || 'No especificado';
+
+        resultadoDiv.innerHTML = `
+          <div class="alert alert-info animate__animated animate__fadeInUp">
+            <h4>${res.resultado}</h4>
+            <p><strong>Estudiante:</strong> ${nombre}</p>
+            <p><strong>Puntaje:</strong> ${res.puntaje} / ${res.maxPuntaje}</p>
+            <img src="${imgSrc}" alt="${res.resultado}" class="resultado-img"/>
+            ${respuestasHTML}
+          </div>
+          <div class="progress mt-3 animate__animated animate__fadeInUp">
           <div id="progressBar" class="progress-bar" role="progressbar" style="width:0%"></div>
         </div>
         <canvas id="resumenChart" class="mt-4"></canvas>

--- a/tests/routes.test.js
+++ b/tests/routes.test.js
@@ -24,10 +24,21 @@ describe('Rutas principales', () => {
     }
     const res = await request(app).post('/api/evaluacion').send(body);
     expect(res.statusCode).toBe(200);
+    expect(res.body).toHaveProperty('nombre', 'Test');
     expect(res.body).toHaveProperty('resultado');
     expect(res.body).toHaveProperty('puntaje', 45);
     expect(res.body).toHaveProperty('maxPuntaje', 45);
     expect(res.body).toHaveProperty('porcentaje', 100);
+  });
+
+  test('POST /api/evaluacion requiere nombre', async () => {
+    const body = {};
+    for (let i = 1; i <= 15; i++) {
+      body[`p${i}`] = 1;
+    }
+    const res = await request(app).post('/api/evaluacion').send(body);
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toHaveProperty('error', 'Nombre requerido');
   });
 
   test('POST /api/evaluacion incluye campo resultado para animación', async () => {


### PR DESCRIPTION
## Summary
- ensure `/api/evaluacion` requires a `nombre` field and echoes it back in responses
- display a default "No especificado" when the student name is missing in the form results
- add tests covering presence/absence of `nombre`

## Testing
- `npm test`
- Manual request to `/api/evaluacion` with valid `nombre`


------
https://chatgpt.com/codex/tasks/task_e_68964683b32883278d592f7698356623