### PR TITLE
Handle missing student name in evaluation results

### DIFF
--- a/public/js/formulario.js
+++ b/public/js/formulario.js
@@ -91,6 +91,10 @@ document.addEventListener('DOMContentLoaded', () => {
         body: JSON.stringify(data)
       });
       const res = await response.json();
+      if (!res.nombre) {
+        resultadoDiv.innerHTML = `<div class="alert alert-danger">Nombre no proporcionado</div>`;
+        return;
+      }
 
       let imgSrc = '/img/alto_riesgo.svg';
       if (res.resultado.includes('éxito')) {
@@ -107,7 +111,7 @@ document.addEventListener('DOMContentLoaded', () => {
           respuestasHTML = `<h5>Respuestas:</h5><ul>${items}</ul>`;
         }
 
-        const nombre = res.nombre || 'No especificado';
+        const nombre = res.nombre;
 
         resultadoDiv.innerHTML = `
           <div class="alert alert-info animate__animated animate__fadeInUp">


### PR DESCRIPTION
## Summary
- Abort result rendering if the API response lacks a student name
- Use server-provided student name without falling back to defaults

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896498c792483278c089fed5c38ce05