### PR TITLE
Remove Chart.js integration from evaluation form

### DIFF
--- a/public/js/formulario.js
+++ b/public/js/formulario.js
@@ -121,24 +121,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
           <div id="progressBar" class="progress-bar" role="progressbar" style="width:0%"></div>
         </div>
-        <canvas id="resumenChart" class="mt-4"></canvas>
       `;
 
       const progressBar = document.getElementById('progressBar');
       progressBar.style.width = `${res.porcentaje}%`;
       progressBar.textContent = `${res.porcentaje.toFixed(2)}%`;
-
-      const ctx = document.getElementById('resumenChart').getContext('2d');
-      new Chart(ctx, {
-        type: 'doughnut',
-        data: {
-          labels: ['Obtenido', 'Restante'],
-          datasets: [{
-            data: [res.puntaje, res.maxPuntaje - res.puntaje],
-            backgroundColor: ['#0d6efd', '#e9ecef']
-          }]
-        }
-      });
 
     } catch (err) {
       resultadoDiv.innerHTML = `<div class="alert alert-danger">Error al procesar la evaluación</div>`;

--- a/views/formulario.ejs
+++ b/views/formulario.ejs
@@ -43,7 +43,6 @@
 
       <div id="resultado" class="mt-4"></div>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <script src="/js/formulario.js"></script>
-  </body>
-  </html>
+      <script src="/js/formulario.js"></script>
+    </body>
+    </html>


### PR DESCRIPTION
## Summary
- Drop Chart.js script and canvas from the evaluation form view.
- Simplify form logic by removing Chart rendering and related canvas code.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896498c13008327acf06e5617bc40e6